### PR TITLE
Change exports from Markdown to Markdown.converter

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -1299,4 +1299,4 @@ var escapeCharacters_callback = function(wholeMatch,m1) {
 } // end of Showdown.converter
 
 // export
-if (typeof exports != 'undefined') exports.converter = Showdown.converter;
+if (typeof exports != 'undefined') exports = Showdown;


### PR DESCRIPTION
I think making exports.Markdown equals to Markdown will make the code complicated:

```
const showdown = require('showdown');
const converter = showdown.Showdown.converter();
converter.makeHtml(text);
```

The original Showdown code only exposes a converter method. That's all the user will need, so exporting this method is enough. Thus I propose exporting the converter method only:

```
if (typeof exports != 'undefined') exports.converter = Showdown.converter;
```
