### PR TITLE
Small piece of code needed to be AMD friendly

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -1339,3 +1339,12 @@ var escapeCharacters_callback = function(wholeMatch,m1) {
 
 // export
 if (typeof module !== 'undefined') module.exports = Showdown;
+
+// stolen from AMD branch of underscore
+// AMD define happens at the end for compatibility with AMD loaders
+// that don't enforce next-turn semantics on modules.
+if (typeof define === 'function' && define.amd) {
+    define('showdown', function() {
+        return Showdown;
+    });
+}


### PR DESCRIPTION
If you are using AMD modules (like require.js or similar) this little chunk of async handling code is needed. I added it adapted from the AMD version of underscore.js. 

It makes it so that you can use showdown like you would use any other module ie:

``` javascript
//Someobject.js
define(function (require, exports, module) {

    var Showdown = require("showdown");
    //... etc.

});
```
