### PR TITLE
Fix excessive runtime by optimizing regex

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -259,13 +259,13 @@ var _HashHTMLBlocks = function(text) {
 			\b					// word break
 								// attacklab: hack around khtml/pcre bug...
 			[^\r]*?				// any number of lines, minimally matching
-			.*</\2>				// the matching end tag
+			</\2>				// the matching end tag
 			[ \t]*				// trailing spaces/tabs
 			(?=\n+)				// followed by a newline
 		)						// attacklab: there are sentinel newlines at end of document
 		/gm,function(){...}};
 	*/
-	text = text.replace(/^(<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|style|section|header|footer|nav|article|aside)\b[^\r]*?.*<\/\2>[ \t]*(?=\n+)\n)/gm,hashElement);
+	text = text.replace(/^(<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|style|section|header|footer|nav|article|aside)\b[^\r]*?<\/\2>[ \t]*(?=\n+)\n)/gm,hashElement);
 
 	// Special case just for <hr />. It was easier to make a special case than
 	// to make the other regex more complicated.

--- a/test/cases/html5-strutural-tags.html
+++ b/test/cases/html5-strutural-tags.html
@@ -9,8 +9,11 @@
 
 <nav>navigation</nav>
 
-<article>read me</article>
+<article>read
+me</article>
 
-<aside>ignore me</aside>
+<aside>
+ignore me
+</aside>
 
 <p>the end</p>

--- a/test/cases/html5-strutural-tags.md
+++ b/test/cases/html5-strutural-tags.md
@@ -5,7 +5,10 @@ These HTML5 tags should pass through just fine.
 <header>head</header>
 <footer>footsies</footer>
 <nav>navigation</nav>
-<article>read me</article>
-<aside>ignore me</aside>
+<article>read
+me</article>
+<aside>
+ignore me
+</aside>
 
 the end


### PR DESCRIPTION
Remove unnecessary "match anything" test that caused excessive run times on some mixed content
Update HTML5 structural tags test to also verify correctness this regexp and the previous one.

I reran mocha tests after this change with no failures.  I needed this because I'm running this as part of a macro in Google Documents, and the old code was triggering an "excessive run time" error due to the regexp taking too long.  Removing this .\* seemed to fix the problem, and I couldn't understand why it would be needed with the preceding match all but CR test.  The \r based tests are very odd, as earlier in the code, there's replace operations that remove any \r's from the text, but I'll take it at face value that they're needed to workaround a PCRE bug.

Note: I did not regenerate the uglify'd version in this patch.
