### PR TITLE
Added support for ender.

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -117,8 +117,11 @@ var g_output_modifiers = [];
 // Automatic Extension Loading (node only):
 //
 
-if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
-	var fs = require('fs');
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefined') {
+	var fs;
+	try {
+		fs = require('fs');
+	} catch(e) {}
 
 	if (fs) {
 		// Search extensions folder


### PR DESCRIPTION
[Ender](https://github.com/ender-js/Ender) adds a way to build client-side packages by implementing the CommonJS module pattern in the browser. Unfortunately, this breaks showdown because `require('fs')` throws an exception (unloaded module).

I also fixed the `typeof bla == 'undefind'` checks while at it.