### PR TITLE
Added support for github @mentions

### DIFF
--- a/src/extensions/github.js
+++ b/src/extensions/github.js
@@ -14,6 +14,14 @@
               replace : function(match, prefix, content, suffix) {
                   return '<del>' + content + '</del>';
               }
+            },
+            {
+              // @mentions
+              type    : 'lang',
+              regex   : '(@([A-Za-z0-9-_]+))',
+              replace : function(match, content, user) {
+                  return '<a href="//github.com/' + user + '">' + content + '</a>'
+              }
             }
         ];
     };


### PR DESCRIPTION
Might cause issues when using both twitter and github extensions for the same text. My assumption was that these were not combined normally.
