### PR TITLE
Bugfix: Clear table output buffer between tables

### DIFF
--- a/src/extensions/table.js
+++ b/src/extensions/table.js
@@ -55,11 +55,12 @@
       return out;
     };
     filter = function(text) { 
-      var i=0, lines = text.split('\n'), tbl = [], line, hs, rows, out = [];
+      var i=0, lines = text.split('\n'), line, hs, rows, out = [];
       for (i; i<lines.length;i+=1) {
         line = lines[i];
         // looks like a table heading
         if (line.trim().match(/^[|]{1}.*[|]{1}$/)) {
+          var tbl = [];
           line = line.trim();
           tbl.push('<table>');
           hs = line.substring(1, line.length -1).split('|');


### PR DESCRIPTION
_Details_
Previously if you had 3 tables it would output like

Table 1
Table 1
Table 2
Table 1
Table 2
Table 3

When we really want

Table 1
Table 2
Table 3
