### PR TITLE
Be more explicit about detecting fs.readdirSync support.

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -120,7 +120,7 @@ var g_output_modifiers = [];
 if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
 	var fs = require('fs');
 
-	if (fs) {
+	if ((typeof fs !== "undefined" && fs !== null ? fs.readdirSync : void 0) != null) {
 		// Search extensions folder
 		var extensions = fs.readdirSync((__dirname || '.')+'/extensions').filter(function(file){
 			return ~file.indexOf('.js');

--- a/src/showdown.js
+++ b/src/showdown.js
@@ -120,7 +120,7 @@ var g_output_modifiers = [];
 if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
 	var fs = require('fs');
 
-	if ((typeof fs !== "undefined" && fs !== null ? fs.readdirSync : void 0) != null) {
+	if (fs && fs.readdirSync) {
 		// Search extensions folder
 		var extensions = fs.readdirSync((__dirname || '.')+'/extensions').filter(function(file){
 			return ~file.indexOf('.js');

--- a/src/showdown.js
+++ b/src/showdown.js
@@ -117,7 +117,7 @@ var g_output_modifiers = [];
 // Automatic Extension Loading (node only):
 //
 
-if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefined') {
 	var fs = require('fs');
 
 	if (fs && fs.readdirSync) {


### PR DESCRIPTION
Tools like Browserify result in a `require('fs')` that returns something not falsey, so this more explicit checking prevents the `fs.readdirSync` call from being attempted unless the function itself exists.