### PR TITLE
Fix CommonJS support

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -64,7 +64,9 @@
 //
 // Showdown namespace
 //
-var Showdown = { extensions: {} };
+var Showdown = typeof exports === 'object' ? exports : {};
+
+Showdown.extensions = {};
 
 //
 // forEach
@@ -1440,9 +1442,6 @@ var escapeCharacters_callback = function(wholeMatch,m1) {
 
 } // end of Showdown.converter
 
-
-// export
-if (typeof module !== 'undefined') module.exports = Showdown;
 
 // stolen from AMD branch of underscore
 // AMD define happens at the end for compatibility with AMD loaders


### PR DESCRIPTION
module.exports is not part of CommonJS and only few CommonJS platforms
support it
exports is the standard way to export a module API
changing the reference of the exports object is also not standard and
not always supported
A related fix has also been recently provided on the Mustache.js project