### PR TITLE
Fix extension example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Alternately, if you'd just like to do everything yourself, you can specify a fil
 var demo = function(converter) {
   return [
     // Replace escaped @ symbols
-    { type: 'lang', function(text) {
+    { type: 'lang', filter: function(text) {
       return text.replace(/\\@/g, '@');
     }}
   ];


### PR DESCRIPTION
var converter = new Showdown.converter({ extensions: 'twitter' });

Since it loops over the value of options.extensions, it ends up looping over each character in the string twitter ['t', 'w', 'i', ...] and fails to load the extension.
