### PR TITLE
a bug about options！

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -219,11 +219,13 @@ if (converter_options && converter_options.extensions) {
 
   var self = this;
   
-  // if a string is given like this new Showdown.converter({ extensions: 'github' })
-  // Ensure it can traverse the extensions list
-  if(typeof converter_options.extensions === 'string'){
-  	converter_options.extensions = [converter_options.extensions];
-  }
+  var extensionList = converter_options.extensions;
+
+	// if a string is given like this new Showdown.converter({ extensions: 'github' })
+	// Ensure it can traverse the extensions list
+	if(typeof extensionList === 'string'){
+	    converter_options.extensions = [extensionList];
+	}
 
 	// Iterate over each plugin
 	Showdown.forEach(converter_options.extensions, function(plugin){

--- a/src/showdown.js
+++ b/src/showdown.js
@@ -218,6 +218,12 @@ this.makeHtml = function(text) {
 if (converter_options && converter_options.extensions) {
 
   var self = this;
+  
+  // if a string is given like this new Showdown.converter({ extensions: 'github' })
+  // Ensure it can traverse the extensions list
+  if(typeof converter_options.extensions === 'string'){
+  	converter_options.extensions = [converter_options.extensions];
+  }
 
 	// Iterate over each plugin
 	Showdown.forEach(converter_options.extensions, function(plugin){


### PR DESCRIPTION
call:
var converter = new Showdown.converter({ extensions: 'github' });

This will cause an exception：
uncaught exception: Extension 'undefined' could not be loaded. It was either not found or is not a valid extension.

and I found that this problem can be avoided use:
var converter = new Showdown.converter({ extensions: ['github'] });

So I submitted this update to resolve the issue
