### PR TITLE
Fixed a typo in the custom filter example (missing filter: object property)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Alternately, if you'd just like to do everything yourself, you can specify a fil
 var demo = function(converter) {
   return [
     // Replace escaped @ symbols
-    { type: 'lang', function(text) {
+    { type: 'lang', filter: function(text) {
       return text.replace(/\\@/g, '@');
     }}
   ];


### PR DESCRIPTION
Example was missing the "filter" property's label.
