### PR TITLE
Fix/don't load swp extension

### DIFF
--- a/src/extensions/twitter.js
+++ b/src/extensions/twitter.js
@@ -2,6 +2,10 @@
 //  Twitter Extension
 //  @username   ->  <a href="http://twitter.com/username">@username</a>
 //  #hashtag    ->  <a href="http://twitter.com/search/%23hashtag">#hashtag</a>
+//  https://twitter.com/jack/status/20 -> <blockquote class="twitter-tweet">
+//                                          <a href="https://twitter.com/jack/status/20">Tweet from @jack</a>
+//                                        </blockquote>
+//                                        <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 //
 
 (function(){
@@ -30,7 +34,16 @@
             }},
 
             // Escaped @'s
-            { type: 'lang', regex: '\\\\@', replace: '@' }
+            { type: 'lang', regex: '\\\\@', replace: '@' },
+            
+            // New line with a twitter url => embedded tweet
+            {
+                type    : 'lang',
+                regex   : '\n(https?:\/\/twitter\.com\/([^\/]{1,15})\/status(es)?\/[0-9]{1,100})',
+                replace : function (match, permalink, username) {
+                    return '<blockquote class="twitter-tweet"><a href="'+permalink+'">Tweet from @'+username+'</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>';
+                }
+            }
         ];
     };
 

--- a/src/extensions/twitter.js
+++ b/src/extensions/twitter.js
@@ -14,9 +14,9 @@
         return [
 
             // @username syntax
-            { type: 'lang', regex: '\\B(\\\\)?@([\\S]+)\\b', replace: function(match, leadingSlash, username) {
-                // Check if we matched the leading \ and return nothing changed if so
-                if (leadingSlash === '\\') {
+            { type: 'lang', regex: '\\B(.)?@([\\S]+)\\b', replace: function(match, leading, username) {
+                // Check if we matched the leading \ or [ and return nothing changed if so
+                if (['\\','['].indexOf(leading) > -1) {
                     return match;
                 } else {
                     return '<a href="http://twitter.com/' + username + '">@' + username + '</a>';
@@ -24,9 +24,9 @@
             }},
 
             // #hashtag syntax
-            { type: 'lang', regex: '\\B(\\\\)?#([\\S]+)\\b', replace: function(match, leadingSlash, tag) {
-                // Check if we matched the leading \ and return nothing changed if so
-                if (leadingSlash === '\\') {
+            { type: 'lang', regex: '\\B(\\\\)?#([\\S]+)\\b', replace: function(match, leading, tag) {
+                // Check if we matched the leading \ or [ and return nothing changed if so
+                if (['\\','['].indexOf(leading) > -1) {
                     return match;
                 } else {
                     return '<a href="http://twitter.com/search/%23' + tag + '">#' + tag + '</a>';

--- a/src/showdown.js
+++ b/src/showdown.js
@@ -123,7 +123,7 @@ if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof req
 	if (fs) {
 		// Search extensions folder
 		var extensions = fs.readdirSync((__dirname || '.')+'/extensions').filter(function(file){
-			return ~file.indexOf('.js');
+			return file.match(/\.js$/);
 		}).map(function(file){
 			return file.replace(/\.js$/, '');
 		});


### PR DESCRIPTION
When you are editing an extension with vim, it automatically creates a `.extensionFilename.js.swp` for autosave. Which is fine since it gets removed after you quit vim, however while this file exist, you can't run your node process because showdown will try to load that temporary file as a possible extension. 

So this is a very small/simple fix for that. 