### PR TITLE
Fix for parsed text links with underscores

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -508,6 +508,9 @@ var _RunSpanGamut = function(text) {
 	// Do hard breaks:
 	text = text.replace(/  +\n/g," <br />\n");
 
+  // Un-escape the escaped underscores now that italics are done
+  text = text.replace(/\%5F/g, '_')
+
 	return text;
 }
 
@@ -1277,6 +1280,9 @@ var _EncodeBackslashEscapes = function(text) {
 var _DoAutoLinks = function(text) {
 
 	text = text.replace(/<((https?|ftp|dict):[^'">\s]+)>/gi,"<a href=\"$1\">$1</a>");
+
+  // Escape the underscores in text links temporarily
+  text = text.replace(/_/g,"%5F")
 
 	// Email addresses: <address@domain.foo>
 


### PR DESCRIPTION
Plain text links with under scores (ex: http://test.com/this_has/one.html) get parsed into italics (and subsequent removal of underscore in url) because of the order of markdown parsing. This causes the URL to no longer go to correct url.

This fixes this by escaping underscores to true url encoded (%5F) and then reverts back to underscore after all parsing is done.