### PR TITLE
explicitly put Showdown in window object if detected

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -1440,6 +1440,10 @@ var escapeCharacters_callback = function(wholeMatch,m1) {
 
 } // end of Showdown.converter
 
+// client-side export
+if (typeof window !== 'undefined') {
+  window.Showdown = Showdown;
+}
 
 // export
 if (typeof module !== 'undefined') module.exports = Showdown;


### PR DESCRIPTION
This means that the extensions will not have any problem attaching themselves to Showdown.  If Showdown is **not** in the `window` object, the extension will not find Showdown, not register itself, and Showdown will raise an exception because the extension you specified does not exist.

Resolves #86 
