### PR TITLE
make showdown compatible with browserify

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -117,7 +117,7 @@ var g_output_modifiers = [];
 // Automatic Extension Loading (node only):
 //
 
-if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
 	var fs = require('fs');
 
 	if (fs) {

--- a/src/showdown.js
+++ b/src/showdown.js
@@ -95,6 +95,9 @@ var stdExtName = function(s) {
 //
 Showdown.converter = function(converter_options) {
 
+// set converter_options to a plain object if its undefined
+converter_options = converter_options === undefined ? {} : converter_options
+
 //
 // Globals:
 //
@@ -117,7 +120,7 @@ var g_output_modifiers = [];
 // Automatic Extension Loading (node only):
 //
 
-if (typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
+if (converter_options.node !== false && typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
 	var fs = require('fs');
 
 	if (fs) {


### PR DESCRIPTION
added ability to disable extensions search on node so that the call to `fs.readdirSync` can be disabled when showdowns is being used with browserify (because that call cannot be handled by browserify)