### PR TITLE
Stricter fs check

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -120,7 +120,7 @@ var g_output_modifiers = [];
 if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
 	var fs = require('fs');
 
-	if (fs) {
+	if (fs && typeof fs.readdirSync === 'function') {
 		// Search extensions folder
 		var extensions = fs.readdirSync((__dirname || '.')+'/extensions').filter(function(file){
 			return ~file.indexOf('.js');


### PR DESCRIPTION
Simply checking for fs is troublesome when using browserify to bundle modules b/c browserify provides a stub object by default. This can be worked around, but it seems like a nice solution to add an extra check here.
