### PR TITLE
fix bug: repeat twice when double table in one md file.

### DIFF
--- a/src/extensions/table.js
+++ b/src/extensions/table.js
@@ -61,7 +61,7 @@
         // looks like a table heading
         if (line.trim().match(/^[|]{1}.*[|]{1}$/)) {
           line = line.trim();
-          tbl.push('<table>');
+          tbl = ['<table>'];
           hs = line.substring(1, line.length -1).split('|');
           tbl.push(tables.thead.apply(this, hs));
           line = lines[++i];


### PR DESCRIPTION
Try this:

```
Table a:

| Col 1   | Col 2                                              |
|======== |====================================================|
| Plain1   | Value2                                              |

Table b:

| Col 1   | Col 2                                              |
|======== |====================================================|
| Plain3   | Value4                                              |
```
