### PR TITLE
Change the test to node

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -117,7 +117,7 @@ var g_output_modifiers = [];
 // Automatic Extension Loading (node only):
 //
 
-if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
+if (typeof process !== 'undefined') {
 	var fs = require('fs');
 
 	if (fs) {


### PR DESCRIPTION
If you export the module enters browserify if, however if used process is a global variable node.