### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Alternately, if you'd just like to do everything yourself, you can specify a fil
 var demo = function(converter) {
   return [
     // Replace escaped @ symbols
-    { type: 'lang', function(text) {
+    { type: 'lang', filter: function(text) {
       return text.replace(/\\@/g, '@');
     }}
   ];


### PR DESCRIPTION
I am not sure whether this was intended, but I guess the code example is missing a "filter: " before the "function(text)".