### PR TITLE
Fix 'undefind' typo in showdown.js

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -117,7 +117,7 @@ var g_output_modifiers = [];
 // Automatic Extension Loading (node only):
 //
 
-if (typeof module !== 'undefind' && typeof exports !== 'undefined' && typeof require !== 'undefind') {
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && typeof require !== 'undefined') {
 	var fs = require('fs');
 
 	if (fs) {


### PR DESCRIPTION
Fix undefind -> should be undefined