### PR TITLE
More hardy node environment check

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -1442,7 +1442,7 @@ var escapeCharacters_callback = function(wholeMatch,m1) {
 
 
 // export
-if (typeof module !== 'undefined') module.exports = Showdown;
+if (typeof module !== 'undefined' && module.exports) module.exports = Showdown;
 
 // stolen from AMD branch of underscore
 // AMD define happens at the end for compatibility with AMD loaders


### PR DESCRIPTION
Checking only `module` is causing issues with other modules in a browser. The actual issue is caused when testing with angular which added a `module` function to the browser. This module then adds a `module.exports` property. Finally, another module that checks both thinks we're in node and tries to do a `require` for additional data.