### PR TITLE
Do not break on alignment characters in headers

### DIFF
--- a/src/extensions/table.js
+++ b/src/extensions/table.js
@@ -66,7 +66,7 @@
           hs = line.substring(1, line.length -1).split('|');
           tbl.push(tables.thead.apply(this, hs));
           line = lines[++i];
-          if (!line.trim().match(/^[|]{1}[-=| ]+[|]{1}$/)) {
+          if (!line.trim().match(/^[|]{1}[-=|: ]+[|]{1}$/)) {
             // not a table rolling back
             line = lines[--i];
           }


### PR DESCRIPTION
Currently the rendering of tables breaks if the header contains alignment symbols (":"). This does not add alignment support but merely prevents the rendering from breaking altogether.