### PR TITLE
Do not break on alignment characters in headers

### DIFF
--- a/src/extensions/table.js
+++ b/src/extensions/table.js
@@ -15,7 +15,7 @@
 
 (function(){
   var table = function(converter) {
-    var tables = {}, style = 'text-align:left;', filter; 
+    var tables = {}, style = 'text-align:left;', filter;
     tables.th = function(header){
       if (header.trim() === "") { return "";}
       var id = header.trim().replace(/ /g, '_').toLowerCase();
@@ -54,7 +54,7 @@
       out += "</tr>\n";
       return out;
     };
-    filter = function(text) { 
+    filter = function(text) {
       var i=0, lines = text.split('\n'), line, hs, rows, out = [];
       for (i; i<lines.length;i+=1) {
         line = lines[i];
@@ -66,7 +66,7 @@
           hs = line.substring(1, line.length -1).split('|');
           tbl.push(tables.thead.apply(this, hs));
           line = lines[++i];
-          if (!line.trim().match(/^[|]{1}[-=| ]+[|]{1}$/)) {
+          if (!line.trim().match(/^[|]{1}[-=|: ]+[|]{1}$/)) {
             // not a table rolling back
             line = lines[--i];
           }
@@ -86,12 +86,12 @@
           }
         }
         out.push(line);
-      }             
+      }
       return out.join('\n');
     };
     return [
-    { 
-      type: 'lang', 
+    {
+      type: 'lang',
       filter: filter
     }
     ];

--- a/test/extensions/table/basic-alignment.html
+++ b/test/extensions/table/basic-alignment.html
@@ -1,0 +1,21 @@
+<table>
+  <thead>
+    <tr>
+      <th id="first_header" style="text-align:left;"> First Header  </th>
+      <th id="second_header" style="text-align:left;"> Second Header </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td style="text-align:left;"><p>Row 1 Cell 1  </p></td>
+      <td style="text-align:left;"><p>Row 1 Cell 2  </p></td>
+    </tr>
+
+    <tr>
+      <td style="text-align:left;"><p>Row 2 Cell 1  </p></td>
+      <td style="text-align:left;"><p>Row 2 Cell 2  </p></td>
+    </tr>
+
+  </tbody>
+</table>

--- a/test/extensions/table/basic-alignment.md
+++ b/test/extensions/table/basic-alignment.md
@@ -1,0 +1,4 @@
+| First Header  | Second Header |
+| :------------ | :------------ |
+| Row 1 Cell 1  | Row 1 Cell 2  |
+| Row 2 Cell 1  | Row 2 Cell 2  |


### PR DESCRIPTION
Currently the rendering of tables breaks if the header contains alignment symbols (":"). This does not add alignment support but merely prevents the rendering from breaking altogether. Also see #129.
