### PR TITLE
Add missing block elements

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -375,7 +375,7 @@ Showdown.converter = function (converter_options) {
          )						// attacklab: there are sentinel newlines at end of document
          /gm,function(){...}};
          */
-        text = text.replace(/^(<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|style|section|header|footer|nav|article|aside)\b[^\r]*?<\/\2>[ \t]*(?=\n+)\n)/gm, hashElement);
+        text = text.replace(/^(<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|style|section|header|footer|nav|article|aside|address|audio|canvas|figure|hgroup|output|video)\b[^\r]*?<\/\2>[ \t]*(?=\n+)\n)/gm,hashElement);
 
         // Special case just for <hr />. It was easier to make a special case than
         // to make the other regex more complicated.

--- a/test/cases/html5-strutural-tags.html
+++ b/test/cases/html5-strutural-tags.html
@@ -14,10 +14,63 @@
 <aside>ignore me</aside>
 
 <article>read
-me</article>
+    me</article>
 
 <aside>
-ignore me
+    ignore me
 </aside>
 
 <p>the end</p>
+
+<table class="test">
+    <tr>
+        <td>Foo</td>
+    </tr>
+    <tr>
+        <td>Bar</td>
+    </tr>
+</table>
+
+<table class="test">
+    <thead>
+    <tr>
+        <td>Foo</td>
+    </tr>
+    </thead>
+    <tr>
+        <td>Bar</td>
+    </tr>
+    <tfoot>
+    <tr>
+        <td>Bar</td>
+    </tr>
+    </tfoot>
+</table>
+
+<audio class="podcastplayer" controls>
+    <source src="foobar.mp3" type="audio/mp3" preload="none"></source>
+    <source src="foobar.off" type="audio/ogg" preload="none"></source>
+</audio>
+
+<video src="foo.ogg">
+    <track kind="subtitles" src="foo.en.vtt" srclang="en" label="English">
+    <track kind="subtitles" src="foo.sv.vtt" srclang="sv" label="Svenska">
+</video>
+
+<address>My street</address>
+
+<canvas id="canvas" width="300" height="300">
+    Sorry, your browser doesn't support the &lt;canvas&gt; element.
+</canvas>
+
+<figure>
+    <img src="mypic.png" alt="An awesome picture">
+    <figcaption>Caption for the awesome picture</figcaption>
+</figure>
+
+<hgroup>
+    <h1>Main title</h1>
+    <h2>Secondary title</h2>
+</hgroup>
+
+<output name="result"></output>

--- a/test/cases/html5-strutural-tags.md
+++ b/test/cases/html5-strutural-tags.md
@@ -14,3 +14,56 @@ ignore me
 </aside>
 
 the end
+
+<table class="test">
+    <tr>
+        <td>Foo</td>
+    </tr>
+    <tr>
+        <td>Bar</td>
+    </tr>
+</table>
+
+<table class="test">
+    <thead>
+        <tr>
+            <td>Foo</td>
+        </tr>
+    </thead>
+    <tr>
+        <td>Bar</td>
+    </tr>
+    <tfoot>
+        <tr>
+            <td>Bar</td>
+        </tr>
+    </tfoot>
+</table>
+
+<audio class="podcastplayer" controls>
+    <source src="foobar.mp3" type="audio/mp3" preload="none"></source>
+    <source src="foobar.off" type="audio/ogg" preload="none"></source>
+</audio>
+
+<video src="foo.ogg">
+    <track kind="subtitles" src="foo.en.vtt" srclang="en" label="English">
+    <track kind="subtitles" src="foo.sv.vtt" srclang="sv" label="Svenska">
+</video>
+
+<address>My street</address>
+
+<canvas id="canvas" width="300" height="300">
+    Sorry, your browser doesn't support the &lt;canvas&gt; element.
+</canvas>
+
+<figure>
+    <img src="mypic.png" alt="An awesome picture">
+    <figcaption>Caption for the awesome picture</figcaption>
+</figure>
+
+<hgroup>
+  <h1>Main title</h1>
+  <h2>Secondary title</h2>
+</hgroup>
+
+<output name="result"></output>


### PR DESCRIPTION
(#140 redone against develop)

fixes #90 

This is the fix we're using in Ghost to add support for additional HTML5 elements. Thought I'd send it over as [requested](https://github.com/showdownjs/showdown/issues/90#issuecomment-70543134)