### PR TITLE
Updated readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Local options can be set:
 
  * **through the constructor**
     ```js
-    var converter = new showdown.Converter({optionKey: 'value');
+    var converter = new showdown.Converter({optionKey: 'value'});
     ```
 
  * **through the setOption() method**


### PR DESCRIPTION
in Example of Setting options -> Locally, While creating showdown.Converter object closing '}' is missing