### PR TITLE
Changelog

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,6 +87,20 @@ module.exports = function (grunt) {
       }
     },
 
+    conventionalGithubReleaser: {
+      release: {
+        options: {
+          auth: {
+            type: 'oauth',
+            token: process.env.GH_TOEKN
+          },
+          changelogOpts: {
+            preset: 'angular'
+          }
+        },
+      }
+    },
+
     simplemocha: {
       node: {
         src: 'test/node/**/*.js',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,10 +76,14 @@ module.exports = function (grunt) {
       }
     },
 
-    changelog: {
+    conventionalChangelog: {
       options: {
-        repository: 'http://github.com/showdownjs/showdown',
-        dest: 'CHANGELOG.md'
+        changelogOpts: {
+          preset: 'angular'
+        }
+      },
+      release: {
+        src: 'CHANGELOG.md'
       }
     },
 
@@ -163,7 +167,7 @@ module.exports = function (grunt) {
   grunt.registerTask('lint', ['jshint', 'jscs']);
   grunt.registerTask('test', ['clean', 'lint', 'concat:test', 'simplemocha:node', 'clean']);
   grunt.registerTask('build', ['test', 'concat:dist', 'uglify']);
-  grunt.registerTask('prep-release', ['build', 'changelog']);
+  grunt.registerTask('prep-release', ['build', 'conventionalChangelog']);
 
   // Default task(s).
   grunt.registerTask('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-conventional-changelog": "^4.0.0",
+    "grunt-conventional-github-releaser": "^0.3.0",
     "grunt-jscs": "^1.2.0",
     "grunt-simple-mocha": "^0.4.0",
     "js-beautify": "^1.5.6",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.6.0",
-    "grunt-conventional-changelog": "^1.1.0",
+    "grunt-conventional-changelog": "^4.0.0",
     "grunt-jscs": "^1.2.0",
     "grunt-simple-mocha": "^0.4.0",
     "js-beautify": "^1.5.6",


### PR DESCRIPTION
chore(deps): bump grunt-conventional-changelog
There are a ton of bug fixes and nice new features.

feat(release): use grunt-conventional-github-releaser
You need to set environment variable `GH_TOKEN` as your github token and make sure you run it after you have pushed your tag.