### PR TITLE
Enable Github code blocks inside block quotes.

### DIFF
--- a/src/subParsers/blockQuotes.js
+++ b/src/subParsers/blockQuotes.js
@@ -25,6 +25,7 @@ showdown.subParser('blockQuotes', function (text, options, globals) {
     bq = bq.replace(/~0/g, '');
 
     bq = bq.replace(/^[ \t]+$/gm, ''); // trim whitespace-only lines
+    bq = showdown.subParser('githubCodeBlocks')(bq, options, globals);
     bq = showdown.subParser('blockGamut')(bq, options, globals); // recurse
 
     bq = bq.replace(/(^|\n)/g, '$1  ');

--- a/test/cases/github-style-codeblock-inside-quote.html
+++ b/test/cases/github-style-codeblock-inside-quote.html
@@ -1,0 +1,15 @@
+<blockquote>
+<p>Define a function in javascript:</p>
+
+<pre><code>function MyFunc(a) {
+  var s = '`';
+  }
+</code></pre>
+
+<blockquote>
+<p>And some nested quote</p>
+
+<pre><code class="html language-html">&lt;div&gt;HTML!&lt;/div&gt;
+</code></pre>
+</blockquote>
+</blockquote>

--- a/test/cases/github-style-codeblock-inside-quote.md
+++ b/test/cases/github-style-codeblock-inside-quote.md
@@ -1,0 +1,13 @@
+> Define a function in javascript:
+>
+> ```
+> function MyFunc(a) {
+>     var s = '`';
+> }
+> ```
+>
+>> And some nested quote
+>>
+>> ```html
+>> <div>HTML!</div>
+>> ```


### PR DESCRIPTION
Including test. Similar to how it is done for lists. Looks good in my tests (already using that code).

I also wondered whether the call to `showdown.subParser('githubCodeBlocks')` should be better part of the `blockGamut` parser as it seems to make sense whenever a block is processed. But I am not deep enough into the showdown code to see the possible side effects.