### PR TITLE
update license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/showdownjs/showdown.git",
     "web": "https://github.com/showdownjs/showdown"
   },
-  "license": "BSD-2-Clause",
+  "license": "BSD-3-Clause",
   "main": "./dist/showdown.js",
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Hello
According to showdown's [license.txt](https://github.com/showdownjs/showdown/blob/master/license.txt), I think showdown is under the [`BSD-3-Clause`](https://opensource.org/licenses/BSD-3-Clause) license.