### PR TITLE
fix(headers): Ensures that Markdown headers are preceded by a space

### DIFF
--- a/src/subParsers/headers.js
+++ b/src/subParsers/headers.js
@@ -40,7 +40,7 @@ showdown.subParser('headers', function (text, options, globals) {
   //  ...
   //  ###### Header 6
   //
-  text = text.replace(/^(#{1,6})[ \t]*(.+?)[ \t]*#*\n+/gm, function (wholeMatch, m1, m2) {
+  text = text.replace(/^(#{1,6})[ \t]+(.+?)[ \t]*#*\n+/gm, function (wholeMatch, m1, m2) {
     var span = showdown.subParser('spanGamut')(m2, options, globals),
         hID = (options.noHeaderId) ? '' : ' id="' + headerId(m2) + '"',
         hLevel = headerLevelStart - 1 + m1.length,

--- a/test/features/#69.header-level-start.md
+++ b/test/features/#69.header-level-start.md
@@ -1,8 +1,8 @@
-#Given
+# Given
 
-#When
+# When
 
-#Then
+# Then
 
 foo
 ===

--- a/test/issues/#nnn.headers-require-spaces.html
+++ b/test/issues/#nnn.headers-require-spaces.html
@@ -1,0 +1,3 @@
+<h1 id="iamaheader">I am a header</h1>
+
+<p>#I am not a header</p>

--- a/test/issues/#nnn.headers-require-spaces.md
+++ b/test/issues/#nnn.headers-require-spaces.md
@@ -1,0 +1,3 @@
+# I am a header
+
+#I am not a header


### PR DESCRIPTION
Changes subParser for headers to require a space or tab character before a header, so that

``` md
  # Header
```

Is a valid header, whereas:

``` md
  #Header
```

Is **not** rendered as a header.

(This seems to be the standard from what I can tell by testing across the internets, but if we'd prefer to make this an option so that it's not a breaking change I'm happy to do that too!)
