### PR TITLE
Replace a.constructor === Array with Array.isArray(a)

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,7 +37,7 @@ showdown.helper.isFunction = function (a) {
  */
 showdown.helper.isArray = function (a) {
   'use strict';
-  return a.constructor === Array;
+  return Array.isArray(a);
 };
 
 /**


### PR DESCRIPTION
Reason being a.constructor === Array is always falsey when you run showdown within Node's VM API.

Related:
https://github.com/nodejs/node/issues/7351