### PR TITLE
Allow use of AMD loader to be used within Node env

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,15 +1,15 @@
 var root = this;
 
-// CommonJS/nodeJS Loader
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = showdown;
-
 // AMD Loader
-} else if (typeof define === 'function' && define.amd) {
+if (typeof define === 'function' && define.amd) {
   define(function () {
     'use strict';
     return showdown;
   });
+
+// CommonJS/nodeJS Loader
+} else if (typeof module !== 'undefined' && module.exports) {
+  module.exports = showdown;
 
 // Regular Browser loader
 } else {


### PR DESCRIPTION
Because of the ordering of the loader, it's not possible use define.amd within a Node environment.  While this isn't a very popular use-case, it's possible to use define.amd inside Node.

This will eliminate the need for my hack to make showdown always force the module.exports expression to be falsey: https://github.com/gcollazo/ember-cli-showdown/blob/master/index.js#L55-L56 in order to allow showdown to work with Ember's loader within Node (for server-side rendering).