### PR TITLE
add "this"

### DIFF
--- a/src/showdown.js
+++ b/src/showdown.js
@@ -3,7 +3,7 @@
  */
 
 // load dependencies
-if (typeof document === 'undefined' && typeof window === 'undefined') {
+if (typeof this.document === 'undefined' && typeof this.window === 'undefined') {
   var jsdom = require('jsdom').jsdom,
       jsdomObj = jsdom('', {}),
       window = jsdomObj.defaultView, // jshint ignore:line


### PR DESCRIPTION
First, feel sorry for my English.
In the closure,  the both "typeof" of "document" & "window"  are return "undefined" without "this" prefix. But they are under the variable  "this". 
So ...