### PR TITLE
chore: use npm ci

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,10 +26,11 @@ install:
   # install node
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
+  - npm i -g npm@latest
   # install grunt-cli globally
   - npm install -g grunt-cli
   # install modules
-  - npm install
+  - npm ci
 
 test_script:
   # Output useful info for debugging

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ node_js:
   - "10"
 
 before_install:
+  - npm i -g npm@latest
   - npm install -g grunt-cli
+
+install:
+  - npm ci
 
 # travis build  speed up
 sudo: false


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable