### PR TITLE
Sanitize README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ var defaultOptions = showdown.getDefaultOptions();
 
  * **ghCodeBlocks**: (boolean) [default true] Enable support for GFM code block style.
 
- * **tasklists**:(boolean) [default false] Enable support for GFM tasklists. Example:
+ * **tasklists**: (boolean) [default false] Enable support for GFM tasklists. Example:
  
    ```md
     - [x] This task is done


### PR DESCRIPTION
No space after ':' creates problem with Boldness of 'tasklists' and description in Wiki