### PR TITLE
fix bug width|height = auto

### DIFF
--- a/src/subParsers/makemarkdown/image.js
+++ b/src/subParsers/makemarkdown/image.js
@@ -2,11 +2,13 @@ showdown.subParser('makeMarkdown.image', function (node) {
   'use strict';
 
   var txt = '';
-  if (node.hasAttribute('src')) {
+  if (node.hasAttribute('src') && node.getAttribute('src') !== '') {
     txt += '![' + node.getAttribute('alt') + '](';
     txt += '<' + node.getAttribute('src') + '>';
     if (node.hasAttribute('width') && node.hasAttribute('height')) {
-      txt += ' =' + node.getAttribute('width') + 'x' + node.getAttribute('height');
+      var width = node.getAttribute('width');
+      var height = node.getAttribute('height');
+      txt += ' =' + (width === 'auto' ? '*' : width) + 'x' + (height === 'auto' ? '*' : height);
     }
 
     if (node.hasAttribute('title')) {


### PR DESCRIPTION
when <img src="a" width="auto" height="auto" /> then ![null](<a> =autoxauto)
after fix ![null](<a> =*x*)