### PR TITLE
fix(polyfill) String.prototype.repeat

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -357,6 +357,45 @@ showdown.helper.encodeEmailAddress = function (mail) {
 };
 
 /**
+ * String.prototype.repeat polyfill
+ *
+ * @param str
+ * @param count
+ * @returns {string}
+ */
+function repeat (str, count) {
+  'use strict';
+  str = '' + str;
+  if (count < 0) {
+    throw new RangeError('repeat count must be non-negative');
+  }
+  if (count === Infinity) {
+    throw new RangeError('repeat count must be less than infinity');
+  }
+  count = Math.floor(count);
+  if (str.length === 0 || count === 0) {
+    return '';
+  }
+  // Ensuring count is a 31-bit integer allows us to heavily optimize the
+  // main part. But anyway, most current (August 2014) browsers can't handle
+  // strings 1 << 28 chars or longer, so:
+  /*jshint bitwise: false*/
+  if (str.length * count >= 1 << 28) {
+    throw new RangeError('repeat count must not overflow maximum string size');
+  }
+  /*jshint bitwise: true*/
+  var maxCount = str.length * count;
+  count = Math.floor(Math.log(count) / Math.log(2));
+  while (count) {
+    str += str;
+    count--;
+  }
+  str += str.substring(0, maxCount - str.length);
+  return str;
+}
+
+/**
+ * String.prototype.padEnd polyfill
  *
  * @param str
  * @param targetLength
@@ -375,7 +414,7 @@ showdown.helper.padEnd = function padEnd (str, targetLength, padString) {
   } else {
     targetLength = targetLength - str.length;
     if (targetLength > padString.length) {
-      padString += padString.repeat(targetLength / padString.length); //append to original to ensure we are longer than needed
+      padString += repeat(padString, targetLength / padString.length); //append to original to ensure we are longer than needed
     }
     return String(str) + padString.slice(0,targetLength);
   }


### PR DESCRIPTION
Similar to my last PR, I ported this library to TypeScript (https://github.com/dennisss/showdown/tree/ts) targeted at the claimed ES3 compatibility of this library.

Found that String.prototype.repeat (ES6) is used in the polyfill for String.prototype.padEnd, so both polyfills are needed to support ES3