### PR TITLE
Add rel="noopener noreferrer" to links when openLinksInNewWindow is on.

### DIFF
--- a/src/subParsers/makehtml/links.js
+++ b/src/subParsers/makehtml/links.js
@@ -117,7 +117,7 @@
     // to external links. Hash links (#) open in same page
     if (options.openLinksInNewWindow && !/^#/.test(url)) {
       // escaped _
-      target = ' rel="noreferrer" target="¨E95Eblank"';
+      target = ' rel="noopener noreferrer" target="¨E95Eblank"';
     }
 
     // Text can be a markdown element, so we run through the appropriate parsers

--- a/src/subParsers/makehtml/links.js
+++ b/src/subParsers/makehtml/links.js
@@ -117,7 +117,7 @@
     // to external links. Hash links (#) open in same page
     if (options.openLinksInNewWindow && !/^#/.test(url)) {
       // escaped _
-      target = ' target="¨E95Eblank"';
+      target = ' rel="noreferrer" target="¨E95Eblank"';
     }
 
     // Text can be a markdown element, so we run through the appropriate parsers

--- a/test/functional/makehtml/cases/features/#379.openLinksInNewWindow-breaks-em-markdup.html
+++ b/test/functional/makehtml/cases/features/#379.openLinksInNewWindow-breaks-em-markdup.html
@@ -1,2 +1,2 @@
-<p>My <a href="http://example.com" rel="noreferrer" target="_blank">link</a> is <em>important</em></p>
-<p>My <a href="http://example.com" rel="noreferrer" target="_blank">link</a> is <strong>important</strong></p>
+<p>My <a href="http://example.com" rel="noopener noreferrer" target="_blank">link</a> is <em>important</em></p>
+<p>My <a href="http://example.com" rel="noopener noreferrer" target="_blank">link</a> is <strong>important</strong></p>

--- a/test/functional/makehtml/cases/features/#379.openLinksInNewWindow-breaks-em-markdup.html
+++ b/test/functional/makehtml/cases/features/#379.openLinksInNewWindow-breaks-em-markdup.html
@@ -1,2 +1,2 @@
-<p>My <a href="http://example.com" target="_blank">link</a> is <em>important</em></p>
-<p>My <a href="http://example.com" target="_blank">link</a> is <strong>important</strong></p>
+<p>My <a href="http://example.com" rel="noreferrer" target="_blank">link</a> is <em>important</em></p>
+<p>My <a href="http://example.com" rel="noreferrer" target="_blank">link</a> is <strong>important</strong></p>

--- a/test/functional/makehtml/cases/features/openLinksInNewWindow/simple-cases.html
+++ b/test/functional/makehtml/cases/features/openLinksInNewWindow/simple-cases.html
@@ -1,2 +1,2 @@
-<p><a href="www.google.com" rel="noreferrer" target="_blank">foo</a></p>
-<p>a link <a href="http://www.google.com" rel="noreferrer" target="_blank">http://www.google.com</a></p>
+<p><a href="www.google.com" rel="noopener noreferrer" target="_blank">foo</a></p>
+<p>a link <a href="http://www.google.com" rel="noopener noreferrer" target="_blank">http://www.google.com</a></p>

--- a/test/functional/makehtml/cases/features/openLinksInNewWindow/simple-cases.html
+++ b/test/functional/makehtml/cases/features/openLinksInNewWindow/simple-cases.html
@@ -1,2 +1,2 @@
-<p><a href="www.google.com" target="_blank">foo</a></p>
-<p>a link <a href="http://www.google.com" target="_blank">http://www.google.com</a></p>
+<p><a href="www.google.com" rel="noreferrer" target="_blank">foo</a></p>
+<p>a link <a href="http://www.google.com" rel="noreferrer" target="_blank">http://www.google.com</a></p>

--- a/test/functional/makehtml/cases/features/openLinksInNewWindow/simple.html
+++ b/test/functional/makehtml/cases/features/openLinksInNewWindow/simple.html
@@ -1,2 +1,2 @@
-<p><a href="www.google.com" rel="noreferrer" target="_blank">foo</a></p>
-<p>a link <a href="http://www.google.com" rel="noreferrer" target="_blank">http://www.google.com</a></p>
+<p><a href="www.google.com" rel="noopener noreferrer" target="_blank">foo</a></p>
+<p>a link <a href="http://www.google.com" rel="noopener noreferrer" target="_blank">http://www.google.com</a></p>

--- a/test/functional/makehtml/cases/features/openLinksInNewWindow/simple.html
+++ b/test/functional/makehtml/cases/features/openLinksInNewWindow/simple.html
@@ -1,2 +1,2 @@
-<p><a href="www.google.com" target="_blank">foo</a></p>
-<p>a link <a href="http://www.google.com" target="_blank">http://www.google.com</a></p>
+<p><a href="www.google.com" rel="noreferrer" target="_blank">foo</a></p>
+<p>a link <a href="http://www.google.com" rel="noreferrer" target="_blank">http://www.google.com</a></p>

--- a/test/functional/makehtml/cases/features/openLinksInNewWindow/simplifiedAutoLink.html
+++ b/test/functional/makehtml/cases/features/openLinksInNewWindow/simplifiedAutoLink.html
@@ -1,1 +1,1 @@
-<p>this is <a href="http://www.google.com" rel="noreferrer" target="_blank">http://www.google.com</a> autolink</p>
+<p>this is <a href="http://www.google.com" rel="noopener noreferrer" target="_blank">http://www.google.com</a> autolink</p>

--- a/test/functional/makehtml/cases/features/openLinksInNewWindow/simplifiedAutoLink.html
+++ b/test/functional/makehtml/cases/features/openLinksInNewWindow/simplifiedAutoLink.html
@@ -1,1 +1,1 @@
-<p>this is <a href="http://www.google.com" target="_blank">http://www.google.com</a> autolink</p>
+<p>this is <a href="http://www.google.com" rel="noreferrer" target="_blank">http://www.google.com</a> autolink</p>


### PR DESCRIPTION
Not sure how well this fits in with your goals for the project, but my understanding is that using `target="_blank"` without also adding `rel="noopener noreferrer"` creates a vulnerability (since the site you're linking to has access to the `window.opener` by default. This pull adds `rel="noopener noreferrer"` to links generated by the `makeHtml` converter when `openLinksInNewWindow` is `true`.

Let me know if I dun goofed or if I can do anything else to help. Thanks for making Showdown!