### PR TITLE
fix(makemarkdown.table): col text align right

### DIFF
--- a/src/subParsers/makemarkdown/table.js
+++ b/src/subParsers/makemarkdown/table.js
@@ -55,7 +55,7 @@ showdown.subParser('makeMarkdown.table', function (node, globals) {
     for (ii = 0; ii < tableArray[i].length; ++ii) {
       if (i === 1) {
         if (tableArray[i][ii].slice(-1) === ':') {
-          tableArray[i][ii] = showdown.helper.padEnd(tableArray[i][ii].slice(-1), cellSpacesCount - 1, '-') + ':';
+          tableArray[i][ii] = showdown.helper.padEnd(tableArray[i][ii].slice(0, -1), cellSpacesCount - 1, '-') + ':';
         } else {
           tableArray[i][ii] = showdown.helper.padEnd(tableArray[i][ii], cellSpacesCount, '-');
         }


### PR DESCRIPTION
fix for html columns align right. currently hmtl cols
with align right get converted to md with align center
e.g. html
`<th style="text-align: right">head</th>`
get converted to
`:---: (suddenly center)`
this pull request fixes that bug

Closes #689