### PR TITLE
fix: octocat emoji image location

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
   "bin": {
     "showdown": "bin/showdown.js"
   },
+  "files": [
+    "bin",
+    "dist"
+  ],
   "devDependencies": {
     "chai": "4.1.x",
     "grunt": "^1.0.3",

--- a/src/subParsers/makemarkdown/break.js
+++ b/src/subParsers/makemarkdown/break.js
@@ -1,0 +1,5 @@
+showdown.subParser('makeMarkdown.break', function () {
+  'use strict';
+
+  return '  \n';
+});

--- a/src/subParsers/makemarkdown/node.js
+++ b/src/subParsers/makemarkdown/node.js
@@ -109,6 +109,10 @@ showdown.subParser('makeMarkdown.node', function (node, globals, spansOnly) {
       txt = showdown.subParser('makeMarkdown.image')(node, globals);
       break;
 
+    case 'br':
+      txt = showdown.subParser('makeMarkdown.break')(node, globals);
+      break;
+
     default:
       txt = node.outerHTML + '\n\n';
   }

--- a/test/functional/makemarkdown/cases/standard/breaks.html
+++ b/test/functional/makemarkdown/cases/standard/breaks.html
@@ -1,0 +1,1 @@
+first line<br />and the second

--- a/test/functional/makemarkdown/cases/standard/breaks.md
+++ b/test/functional/makemarkdown/cases/standard/breaks.md
@@ -1,0 +1,2 @@
+first line  
+and the second 


### PR DESCRIPTION
the old link (https://assets-cdn.github.com/images/icons/emoji/octocat.png) will return 404. I have replaced it with the new location for this emoji (https://github.githubassets.com/images/icons/emoji/octocat.png?v8)

Old location:
![](https://assets-cdn.github.com/images/icons/emoji/octocat.png)
New location:
![](https://github.githubassets.com/images/icons/emoji/octocat.png?v8)