### PR TITLE
fix(lists): Fix tasklists to comply with GFM

### DIFF
--- a/src/subParsers/makehtml/lists.js
+++ b/src/subParsers/makehtml/lists.js
@@ -40,7 +40,7 @@ showdown.subParser('makehtml.lists', function (text, options, globals) {
     // attacklab: add sentinel to emulate \z
     listStr += '¨0';
 
-    var rgx = /(\n)?(^ {0,3})([*+-]|\d+[.])[ \t]+((\[(x|X| )?])?[ \t]*[^\r]+?(\n{1,2}))(?=\n*(¨0| {0,3}([*+-]|\d+[.])[ \t]+))/gm,
+    var rgx = /(\n)?(^ {0,3})([*+-]|\d+[.])[ \t]+((\[(x|X| )])?[ \t]*[^\r]+?(\n{1,2}))(?=\n*(¨0| {0,3}([*+-]|\d+[.])[ \t]+))/gm,
         isParagraphed = (/\n[ \t]*\n(?!¨0)/.test(listStr));
 
     // Since version 1.5, nesting sublists requires 4 spaces (or 1 tab) indentation,
@@ -48,7 +48,7 @@ showdown.subParser('makehtml.lists', function (text, options, globals) {
     // activating this option reverts to old behavior
     // This will be removed in version 2.0
     if (options.disableForced4SpacesIndentedSublists) {
-      rgx = /(\n)?(^ {0,3})([*+-]|\d+[.])[ \t]+((\[(x|X| )?])?[ \t]*[^\r]+?(\n{1,2}))(?=\n*(¨0|\2([*+-]|\d+[.])[ \t]+))/gm;
+      rgx = /(\n)?(^ {0,3})([*+-]|\d+[.])[ \t]+((\[(x|X| )])?[ \t]*[^\r]+?(\n{1,2}))(?=\n*(¨0|\2([*+-]|\d+[.])[ \t]+))/gm;
     }
 
     listStr = listStr.replace(rgx, function (wholeMatch, m1, m2, m3, m4, taskbtn, checked) {

--- a/test/functional/makehtml/cases/features/#164.4.tasklists.html
+++ b/test/functional/makehtml/cases/features/#164.4.tasklists.html
@@ -1,8 +1,9 @@
 <h1 id="mythings">my things</h1>
 <ul>
     <li>foo</li>
-    <li class="task-list-item" style="list-style-type: none;"><input type="checkbox" disabled style="margin: 0px 0.35em 0.25em -1.6em; vertical-align: middle;"> bar</li>
+    <li>[] bar</li>
     <li class="task-list-item" style="list-style-type: none;"><input type="checkbox" disabled style="margin: 0px 0.35em 0.25em -1.6em; vertical-align: middle;"> baz</li>
     <li class="task-list-item" style="list-style-type: none;"><input type="checkbox" disabled style="margin: 0px 0.35em 0.25em -1.6em; vertical-align: middle;" checked> bazinga</li>
+    <li class="task-list-item" style="list-style-type: none;"><input type="checkbox" disabled style="margin: 0px 0.35em 0.25em -1.6em; vertical-align: middle;" checked> bazinga 2</li>
 </ul>
 <p>otherthings</p>

--- a/test/functional/makehtml/cases/features/#164.4.tasklists.md
+++ b/test/functional/makehtml/cases/features/#164.4.tasklists.md
@@ -4,5 +4,6 @@
  - [] bar
  - [ ] baz
  - [x] bazinga
+ - [X] bazinga 2
 
 otherthings


### PR DESCRIPTION
GFM requires a whitespace between brackets for tasklists.
Lists with empty brackets at the beginning shouldn't be converted to tasklists.

Closes #655