### PR TITLE
Fixed makeMarkdown not converting <u></u> tags to underscores

### DIFF
--- a/src/subParsers/makemarkdown/node.js
+++ b/src/subParsers/makemarkdown/node.js
@@ -113,6 +113,10 @@ showdown.subParser('makeMarkdown.node', function (node, globals, spansOnly) {
       txt = showdown.subParser('makeMarkdown.break')(node, globals);
       break;
 
+    case 'u':
+      txt = showdown.subParser('makeMarkdown.underline')(node, globals);
+      break;
+
     default:
       txt = node.outerHTML + '\n\n';
   }

--- a/src/subParsers/makemarkdown/underline.js
+++ b/src/subParsers/makemarkdown/underline.js
@@ -1,0 +1,15 @@
+showdown.subParser('makeMarkdown.underline', function (node, globals) {
+  'use strict';
+
+  var txt = '';
+  if (node.hasChildNodes()) {
+    txt += '__';
+    var children = node.childNodes,
+        childrenLength = children.length;
+    for (var i = 0; i < childrenLength; ++i) {
+      txt += showdown.subParser('makeMarkdown.node')(children[i], globals);
+    }
+    txt += '__';
+  }
+  return txt;
+});

--- a/test/functional/makemarkdown/cases/standard/underline.html
+++ b/test/functional/makemarkdown/cases/standard/underline.html
@@ -1,0 +1,2 @@
+<p><u>This gets underlined.</u></p>
+<p>__But this does not get underlined.__</p>

--- a/test/functional/makemarkdown/cases/standard/underline.md
+++ b/test/functional/makemarkdown/cases/standard/underline.md
@@ -1,0 +1,3 @@
+__This gets underlined.__
+
+\_\_But this does not get underlined.\_\_


### PR DESCRIPTION
Hey! I noticed an issue with showdown converter that while makeHtml method converts all markdown to HTML correctly, the makeMarkdown method is not converting `<u></u>` tags back to underscores!

This PR correctly converts `<u>Text</u>` content to `__Text__` when calling the makeMarkdown method.