### PR TITLE
docs: updated triggers for the documentation flow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,13 @@
 name: documentation
 
-on: [push]
+on:
+  push:
+    branches:    
+      - master
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
 
 jobs:
   build_docs:


### PR DESCRIPTION
With this update, the documentation flow will be triggered only for the `master` branch when there are changes in the:

- `mkdocs.yml` file
- `.github/workflows/docs.yml` workflow file
- `docs` folder