### PR TITLE
docs: added 'corporate' colors for docs

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,0 +1,4 @@
+:root {
+  --md-primary-fg-color: rgb(196, 54, 39);
+  --md-accent-fg-color: rgb(62, 139, 138);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,9 +7,6 @@ theme:
   favicon: http://showdownjs.com/apple-touch-icon.png
   icon:
     repo: fontawesome/brands/github
-  palette:
-    primary: red
-    accent: cyan
   features:
     - navigation.tabs
 
@@ -19,6 +16,9 @@ markdown_extensions:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
 
+extra_css:
+  - assets/extra.css 
+  
 repo_url: https://github.com/showdownjs/showdown
 repo_name: showdownjs/showdown
 site_dir: public


### PR DESCRIPTION
Theme color and accent (hover) color:
<img width="401" alt="colors" src="https://user-images.githubusercontent.com/16765690/160170933-5fb55783-ccb6-422f-af40-30e363c9cc1d.png">
