### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/test/functional/makehtml/testsuite.features.js
+++ b/test/functional/makehtml/testsuite.features.js
@@ -199,7 +199,7 @@ describe('makeHtml() features testsuite', function () {
 
     function testImageUrlExists (imgUrl) {
       // Strip the quotes
-      imgUrl = imgUrl.substr(0, imgUrl.length - 1).substr(1);
+      imgUrl = imgUrl.slice(1, -1);
       return function (done) {
         (imgUrl.startsWith('http://') ? http : https).get(imgUrl, function (res) {
           expect(res.statusCode).to.equal(200);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.