### PR TITLE
fix(subParsers): strip international punctuation from github headers

### DIFF
--- a/src/subParsers/makehtml/heading.js
+++ b/src/subParsers/makehtml/heading.js
@@ -140,7 +140,7 @@ showdown.subParser('makehtml.heading.id', function (m, options, globals) {
       .replace(/¨D/g, '')
       // replace rest of the chars (&~$ are repeated as they might have been escaped)
       // borrowed from github's redcarpet (so they should produce similar results)
-      .replace(/[&+$,\/:;=?@"#{}|^¨~\[\]`\\*)(%.!'<>]/g, '')
+      .replace(/[&+$,\/:;=?@"#{}|^¨¿？：~\[\]`、゠＝…‥『』〝〟「」゠＝…‥\\*()｛｝（）［］【】%.。，¡!！'<>]/g, '')
       .toLowerCase();
   } else if (options.rawHeaderId) {
     title = title

--- a/test/functional/makehtml/cases/features/#320.github-compatible-generated-header-id.html
+++ b/test/functional/makehtml/cases/features/#320.github-compatible-generated-header-id.html
@@ -1,3 +1,3 @@
 <h1 id="some-header">some header</h1>
-<h1 id="some-header-with--chars">some header with &amp;+$,/:;=?@\"#{}|^~[]`\*()%.!' chars</h1>
+<h1 id="some-header-with--chars">some header with &amp;+$,/:;=?@\"#{}|^¨¿？：~[]`゠＝…‥『』〝〟「」\*()｛｝（）［］【】%.。，¡!！' chars</h1>
 <h1 id="another-header--with--chars">another header &gt; with &lt; chars</h1>

--- a/test/functional/makehtml/cases/features/#320.github-compatible-generated-header-id.md
+++ b/test/functional/makehtml/cases/features/#320.github-compatible-generated-header-id.md
@@ -1,5 +1,5 @@
 # some header
 
-# some header with &+$,/:;=?@\"#{}|^~[]`\\*()%.!' chars
+# some header with &+$,/:;=?@\"#{}|^¨¿？：~[]`゠＝…‥『』〝〟「」\\*()｛｝（）［］【】%.。，¡!！' chars
 
 # another header > with < chars


### PR DESCRIPTION
Fixes #949 