### PR TITLE
fix: properly handle a false value for the parseImgDimensions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ var defaultOptions = showdown.getDefaultOptions();
     <h3>foo</h3>
     ```
 
- * **parseImgDimensions**: (boolean) [default false] Enable support for setting image dimensions from within markdown syntax.
+ * **parseImgDimensions**: (boolean) [default true] Enable support for setting image dimensions from within markdown syntax.
    Examples:
    ```
    ![foo](foo.jpg =100x80)     simple, assumes units are in px

--- a/docs/available-options.md
+++ b/docs/available-options.md
@@ -475,7 +475,7 @@ Open links in new windows.
 Set image dimensions from within Markdown syntax.
 
 * type: `boolean`
-* default value: `false`
+* default value: `true`
 * introduced in: `1.1.0`
 
 === "example"

--- a/src/options.js
+++ b/src/options.js
@@ -42,7 +42,7 @@ function getDefaultOpts (simple) {
       type: 'integer'
     },
     parseImgDimensions: {
-      defaultValue: false,
+      defaultValue: true,
       describe: 'Turn on/off image dimension parsing',
       type: 'boolean'
     },

--- a/src/subParsers/makehtml/images.js
+++ b/src/subParsers/makehtml/images.js
@@ -6,25 +6,11 @@ showdown.subParser('makehtml.images', function (text, options, globals) {
 
   text = globals.converter._dispatch('makehtml.images.before', text, options, globals).getText();
 
-  var inlineRegExp,
-      crazyRegExp,
-      base64RegExp,
-      referenceRegExp,
-      refShortcutRegExp;
-
-  if (options.parseImgDimensions) {
-    inlineRegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?([\S]+?(?:\([\S]*?\)[\S]*?)?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g;
-    crazyRegExp       = /!\[([^\]]*?)][ \t]*()\([ \t]?<([^>]*)>(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(?:(["'])([^"]*?)\6))?[ \t]?\)/g;
-    base64RegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g;
-    referenceRegExp   = /!\[([^\]]*?)] ?(?:\n *)?\[([\s\S]*?)]()()()()()/g;
-    refShortcutRegExp = /!\[([^\[\]]+)]()()()()()/g;
-  } else {
-    inlineRegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?([\S]+?(?:\([\S]*?\)[\S]*?)?)>?()()[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g;
-    crazyRegExp       = /!\[([^\]]*?)][ \t]*()\([ \t]?<([^>]*)>()()[ \t]*(?:(?:(["'])([^"]*?)\6))?[ \t]?\)/g;
-    base64RegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?()()[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g;
-    referenceRegExp   = /!\[([^\]]*?)] ?(?:\n *)?\[([\s\S]*?)]()()()()()/g;
-    refShortcutRegExp = /!\[([^\[\]]+)]()()()()()/g;
-  }
+  var inlineRegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?([\S]+?(?:\([\S]*?\)[\S]*?)?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g,
+      crazyRegExp       = /!\[([^\]]*?)][ \t]*()\([ \t]?<([^>]*)>(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(?:(["'])([^"]*?)\6))?[ \t]?\)/g,
+      base64RegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g,
+      referenceRegExp   = /!\[([^\]]*?)] ?(?:\n *)?\[([\s\S]*?)]()()()()()/g,
+      refShortcutRegExp = /!\[([^\[\]]+)]()()()()()/g;
 
   function writeImageTagBase64 (wholeMatch, altText, linkId, url, width, height, m5, title) {
     url = url.replace(/\s/g, '');
@@ -89,7 +75,7 @@ showdown.subParser('makehtml.images', function (text, options, globals) {
       result += ' title="' + title + '"';
     }
 
-    if (width && height) {
+    if (options.parseImgDimensions && width && height) {
       width  = (width === '*') ? 'auto' : width;
       height = (height === '*') ? 'auto' : height;
 

--- a/src/subParsers/makehtml/images.js
+++ b/src/subParsers/makehtml/images.js
@@ -6,11 +6,25 @@ showdown.subParser('makehtml.images', function (text, options, globals) {
 
   text = globals.converter._dispatch('makehtml.images.before', text, options, globals).getText();
 
-  var inlineRegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?([\S]+?(?:\([\S]*?\)[\S]*?)?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g,
-      crazyRegExp       = /!\[([^\]]*?)][ \t]*()\([ \t]?<([^>]*)>(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(?:(["'])([^"]*?)\6))?[ \t]?\)/g,
-      base64RegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g,
-      referenceRegExp   = /!\[([^\]]*?)] ?(?:\n *)?\[([\s\S]*?)]()()()()()/g,
-      refShortcutRegExp = /!\[([^\[\]]+)]()()()()()/g;
+  var inlineRegExp,
+      crazyRegExp,
+      base64RegExp,
+      referenceRegExp,
+      refShortcutRegExp;
+
+  if (options.parseImgDimensions) {
+    inlineRegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?([\S]+?(?:\([\S]*?\)[\S]*?)?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g;
+    crazyRegExp       = /!\[([^\]]*?)][ \t]*()\([ \t]?<([^>]*)>(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(?:(["'])([^"]*?)\6))?[ \t]?\)/g;
+    base64RegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g;
+    referenceRegExp   = /!\[([^\]]*?)] ?(?:\n *)?\[([\s\S]*?)]()()()()()/g;
+    refShortcutRegExp = /!\[([^\[\]]+)]()()()()()/g;
+  } else {
+    inlineRegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?([\S]+?(?:\([\S]*?\)[\S]*?)?)>?()()[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g;
+    crazyRegExp       = /!\[([^\]]*?)][ \t]*()\([ \t]?<([^>]*)>()()[ \t]*(?:(?:(["'])([^"]*?)\6))?[ \t]?\)/g;
+    base64RegExp      = /!\[([^\]]*?)][ \t]*()\([ \t]?<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?()()[ \t]*(?:(["'])([^"]*?)\6)?[ \t]?\)/g;
+    referenceRegExp   = /!\[([^\]]*?)] ?(?:\n *)?\[([\s\S]*?)]()()()()()/g;
+    refShortcutRegExp = /!\[([^\[\]]+)]()()()()()/g;
+  }
 
   function writeImageTagBase64 (wholeMatch, altText, linkId, url, width, height, m5, title) {
     url = url.replace(/\s/g, '');

--- a/src/subParsers/makehtml/stripLinkDefinitions.js
+++ b/src/subParsers/makehtml/stripLinkDefinitions.js
@@ -6,8 +6,16 @@
 showdown.subParser('makehtml.stripLinkDefinitions', function (text, options, globals) {
   'use strict';
 
-  var regex       = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?([^>\s]+)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n+|(?=¨0))/gm,
-      base64Regex = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n\n|(?=¨0)|(?=\n\[))/gm;
+  var regex,
+      base64Regex;
+
+  if (options.parseImgDimensions) {
+    regex       = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?([^>\s]+)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n+|(?=¨0))/gm;
+    base64Regex = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n\n|(?=¨0)|(?=\n\[))/gm;
+  } else {
+    regex       = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?([^>\s]+)>?()()[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n+|(?=¨0))/gm;
+    base64Regex = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?()()[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n\n|(?=¨0)|(?=\n\[))/gm;
+  }
 
   // attacklab: sentinel workarounds for lack of \A and \Z, safari\khtml bug
   text += '¨0';

--- a/src/subParsers/makehtml/stripLinkDefinitions.js
+++ b/src/subParsers/makehtml/stripLinkDefinitions.js
@@ -6,16 +6,8 @@
 showdown.subParser('makehtml.stripLinkDefinitions', function (text, options, globals) {
   'use strict';
 
-  var regex,
-      base64Regex;
-
-  if (options.parseImgDimensions) {
-    regex       = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?([^>\s]+)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n+|(?=¨0))/gm;
-    base64Regex = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n\n|(?=¨0)|(?=\n\[))/gm;
-  } else {
-    regex       = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?([^>\s]+)>?()()[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n+|(?=¨0))/gm;
-    base64Regex = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?()()[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n\n|(?=¨0)|(?=\n\[))/gm;
-  }
+  var regex       = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?([^>\s]+)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n+|(?=¨0))/gm,
+      base64Regex = /^ {0,3}\[([^\]]+)]:[ \t]*\n?[ \t]*<?(data:.+?\/.+?;base64,[A-Za-z0-9+/=\n]+?)>?(?: =([*\d]+[A-Za-z%]{0,4})x([*\d]+[A-Za-z%]{0,4}))?[ \t]*\n?[ \t]*(?:(\n*)["|'(](.+?)["|')][ \t]*)?(?:\n\n|(?=¨0)|(?=\n\[))/gm;
 
   // attacklab: sentinel workarounds for lack of \A and \Z, safari\khtml bug
   text += '¨0';

--- a/test/functional/makehtml/cases/features/#143.not.support-image-dimensions.html
+++ b/test/functional/makehtml/cases/features/#143.not.support-image-dimensions.html
@@ -1,3 +1,2 @@
-<p>![my image](./pic/pic1_50.png =100pxx20px)</p>
-<p>![my image2][1]</p>
-<p>[1]: ./pic/pic1_50.png =100pxx20px</p>
+<p><img src="./pic/pic1_50.png" alt="my image" /></p>
+<p><img src="./pic/pic1_50.png" alt="my image2" /></p>

--- a/test/functional/makehtml/cases/features/#143.not.support-image-dimensions.html
+++ b/test/functional/makehtml/cases/features/#143.not.support-image-dimensions.html
@@ -1,0 +1,3 @@
+<p>![my image](./pic/pic1_50.png =100pxx20px)</p>
+<p>![my image2][1]</p>
+<p>[1]: ./pic/pic1_50.png =100pxx20px</p>

--- a/test/functional/makehtml/cases/features/#143.not.support-image-dimensions.md
+++ b/test/functional/makehtml/cases/features/#143.not.support-image-dimensions.md
@@ -1,0 +1,5 @@
+![my image](./pic/pic1_50.png =100pxx20px)
+
+![my image2][1]
+
+[1]: ./pic/pic1_50.png =100pxx20px

--- a/test/functional/makehtml/testsuite.features.js
+++ b/test/functional/makehtml/testsuite.features.js
@@ -32,6 +32,8 @@ describe('makeHtml() features testsuite', function () {
       var converter;
       if (testsuite[i].name === '#143.support-image-dimensions') {
         converter = new showdown.Converter({parseImgDimensions: true});
+      } else if (testsuite[i].name === '#143.not.support-image-dimensions') {
+        converter = new showdown.Converter({parseImgDimensions: false});
       } else if (testsuite[i].name === '#69.header-level-start') {
         converter = new showdown.Converter({headerLevelStart: 3});
       } else if (testsuite[i].name === '#164.1.simple-autolink' || testsuite[i].name === '#204.certain-links-with-at-and-dot-break-url') {


### PR DESCRIPTION
Contains two fixes:

1. Change the default value of the `parseImgDimensions` option to `true` (also in documentation)
2. Properly reject image dimensions when the option is set to `false`

Closes #984 