### PR TITLE
Option to use HTTPS for links without protocol https://github.com/showdownjs/showdown/issues/806

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -54,7 +54,7 @@ function getDefaultOpts (simple) {
     httpsAutoLinks: {
       defaultValue:  false,
       describe: 'Use \'https://\' for auto-generated links',
-      type: 'string'
+      type: 'boolean'
     },
     literalMidWordUnderscores: {
       defaultValue: false,

--- a/src/options.js
+++ b/src/options.js
@@ -51,6 +51,11 @@ function getDefaultOpts (simple) {
       describe: 'Turn on/off GFM autolink style',
       type: 'boolean'
     },
+    httpsAutoLinks: {
+      defaultValue:  false,
+      describe: 'Use \'https://\' for auto-generated links',
+      type: 'string'
+    },
     literalMidWordUnderscores: {
       defaultValue: false,
       describe: 'Parse midword underscores as literal underscores',

--- a/src/subParsers/makehtml/links.js
+++ b/src/subParsers/makehtml/links.js
@@ -302,7 +302,7 @@
     var urlRgx  = /<(((?:https?|ftp):\/\/|www\.)[^'">\s]+)>/gi;
     text = text.replace(urlRgx, function (wholeMatch, url, urlStart) {
       var text = url;
-      url = (urlStart === 'www.') ? 'http://' + url : url;
+      url = (urlStart === 'www.') ? (options.httpsAutoLinks ? 'https://' : 'http://') + url : url;
       var evt = createEvent(urlRgx, evtRootName + '.captureStart', wholeMatch, text, null, url, null, options, globals);
       return writeAnchorTag(evt, options, globals);
     });
@@ -392,7 +392,7 @@
       // we copy the treated url to the text variable
       var text = url;
       // finally, if it's a www shortcut, we prepend http
-      url = (urlPrefix === 'www.') ? 'http://' + url : url;
+      url = (urlPrefix === 'www.') ? (options.httpsAutoLinks ? 'https://' : 'http://') + url : url;
 
       // url part is done so let's take care of text now
       // we need to escape the text (because of links such as www.example.com/foo__bar__baz)

--- a/test/functional/makehtml/cases/features/#806.https-auto-link.html
+++ b/test/functional/makehtml/cases/features/#806.https-auto-link.html
@@ -1,0 +1,2 @@
+<p><a href="https://www.foobar.com">www.foobar.com</a></p>
+<p>This is a link <a href="https://www.foobar.com">www.foobar.com</a></p>

--- a/test/functional/makehtml/cases/features/#806.https-auto-link.md
+++ b/test/functional/makehtml/cases/features/#806.https-auto-link.md
@@ -1,0 +1,3 @@
+www.foobar.com
+
+This is a link <www.foobar.com>

--- a/test/functional/makehtml/testsuite.features.js
+++ b/test/functional/makehtml/testsuite.features.js
@@ -64,6 +64,8 @@ describe('makeHtml() features testsuite', function () {
         converter = new showdown.Converter({simpleLineBreaks: true});
       } else if (testsuite[i].name === '#318.simpleLineBreaks-does-not-work-with-chinese-characters') {
         converter = new showdown.Converter({simpleLineBreaks: true});
+      } else if (testsuite[i].name === '#806.https-auto-link') {
+        converter = new showdown.Converter({simplifiedAutoLink: true, httpsAutoLinks: true});
       } else if (testsuite[i].name === 'simpleLineBreaks-handle-html-pre') {
         converter = new showdown.Converter({simpleLineBreaks: true});
       } else if (testsuite[i].name === 'excludeTrailingPunctuationFromURLs-option') {


### PR DESCRIPTION
This PR adds the option `httpsAutoLinks` to use http**s** when encountering links without a specified protocol, e.g. when using simplifiedAutoLink.

This fixes Issue https://github.com/showdownjs/showdown/issues/806