### PR TITLE
Fix parsing metadata key-value pairs

### DIFF
--- a/src/subParsers/makehtml/metadata.js
+++ b/src/subParsers/makehtml/metadata.js
@@ -66,7 +66,7 @@ showdown.subParser('makehtml.metadata', function (text, options, globals) {
       // replace multiple spaces
       .replace(/\n {4}/g, ' ');
 
-    content.replace(/^([\S ]+): +([\s\S]+?)$/gm, function (wm, key, value) {
+    content.replace(/^([\S ]+?): +([\s\S]+?)$/gm, function (wm, key, value) {
       globals.metadata.parsed[key] = value;
       return '';
     });

--- a/test/unit/showdown.Converter.makeHtml.js
+++ b/test/unit/showdown.Converter.makeHtml.js
@@ -64,6 +64,7 @@ describe('showdown.Converter', function () {
           '---SIMPLE\n' +
           'foo: bar\n' +
           'baz: bazinga\n' +
+          'lorem: ipsum: dolor\n' +
           '---\n',
         text2 =
           '---TIVIE\n' +
@@ -75,8 +76,8 @@ describe('showdown.Converter', function () {
       converter.setOption('metadata', true);
 
       let expectedHtml = '',
-          expectedObj = {foo: 'bar', baz: 'bazinga'},
-          expectedRaw = 'foo: bar\nbaz: bazinga',
+          expectedObj = {foo: 'bar', baz: 'bazinga', lorem: 'ipsum: dolor'},
+          expectedRaw = 'foo: bar\nbaz: bazinga\nlorem: ipsum: dolor',
           expectedFormat = 'SIMPLE';
       converter.makeHtml(text1).should.equal(expectedHtml);
       converter.getMetadata().should.eql(expectedObj);


### PR DESCRIPTION
Fixes how metadata key-value pairs are split so that values can contain color characters.

Addresses #511