### PR TITLE
Failover to globalThis

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,4 +1,4 @@
-var root = this;
+var root = this || globalThis;
 
 // AMD Loader
 if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
This PR only modifies one line in `loader.js` to failover to `globalThis` if `this` is undefined.

This fixes the problem of `showdown` crashing when used on the client side as a module  (See https://github.com/kurmasz/showdown_mre) for a MRE.