### PR TITLE
Refactor regex for inline links with unusual letters

### DIFF
--- a/src/subParsers/makehtml/links.js
+++ b/src/subParsers/makehtml/links.js
@@ -210,7 +210,7 @@
     // 3. inline links with no title or titles wrapped in ' or ":
     // [text](url.com) || [text](<url.com>) || [text](url.com "title") || [text](<url.com> "title")
     //var rgx2 = /\[[ ]*[\s]?[ ]*([^\n\[\]]*?)[ ]*[\s]?[ ]*] ?()\(<?[ ]*[\s]?[ ]*([^\s'"]*)>?(?:[ ]*[\n]?[ ]*()(['"])(.*?)\5)?[ ]*[\s]?[ ]*\)/; // this regex is too slow!!!
-    var rgx2 = /\[([\S ]*?)]\s?()\( *<?([^\s'"]*?(?:\([\S]*?\)[\S]*?)?)>?\s*(?:()(['"])(.*?)\5)? *\)/g;
+    var rgx2 = /\[([\S ]*?)]\s?()\( *<?([^)\s'"]*?(?:\([\S]*?\)[\S]*?)?)>?\s*(?:()(['"])(.*?)\5)? *\)/g;
     text = text.replace(rgx2, replaceAnchorTagBaseUrl(rgx2, evtRootName, options, globals));
 
     // 4. inline links with titles wrapped in (): [foo](bar.com (title))


### PR DESCRIPTION
This pull request updates the regular expression used for parsing inline links in the `src/subParsers/makehtml/links.js` file. The change makes the regex more robust by preventing it from including closing parentheses in the URL portion of the match, which could previously lead to incorrect parsing of links.

**Improvements to inline link parsing:**

* Updated the inline link regular expression in `links.js` to exclude closing parentheses from the URL match, improving the accuracy of link parsing.