### PR TITLE
feat(links): add httpsAutoLinks option (rebased #998 onto develop)

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -51,6 +51,11 @@ function getDefaultOpts (simple) {
       describe: 'Turn on/off GFM autolink style',
       type: 'boolean'
     },
+    httpsAutoLinks: {
+      defaultValue: false,
+      describe: 'Use \'https://\' for auto-generated links',
+      type: 'boolean'
+    },
     literalMidWordUnderscores: {
       defaultValue: false,
       describe: 'Parse midword underscores as literal underscores',

--- a/src/subParsers/makehtml/link.js
+++ b/src/subParsers/makehtml/link.js
@@ -78,7 +78,7 @@ showdown.subParser('makehtml.link', function (text, options, globals) {
   let angleBracketsLinksRegex = /<(((?:https?|ftp):\/\/|www\.)[^'">\s]+)>/gi;
   text = text.replace(angleBracketsLinksRegex, function (wholeMatch, url, urlStart) {
     let text = url;
-    url = (urlStart === 'www.') ? 'http://' + url : url;
+    url = (urlStart === 'www.') ? (options.httpsAutoLinks ? 'https://' : 'http://') + url : url;
     return writeAnchorTag ('angleBrackets', angleBracketsLinksRegex, wholeMatch, text, null, url);
   });
 
@@ -164,8 +164,8 @@ showdown.subParser('makehtml.link', function (text, options, globals) {
 
       // we copy the treated url to the text variable
       let txt = url;
-      // finally, if it's a www shortcut, we prepend http
-      url = (urlPrefix === 'www.') ? 'http://' + url : url;
+      // finally, if it's a www shortcut, we prepend http(s)
+      url = (urlPrefix === 'www.') ? (options.httpsAutoLinks ? 'https://' : 'http://') + url : url;
 
       // url part is done so let's take care of text now
       // we need to escape the text (because of links such as www.example.com/foo__bar__baz)

--- a/test/functional/makehtml/cases/features/#806.https-auto-link.html
+++ b/test/functional/makehtml/cases/features/#806.https-auto-link.html
@@ -1,0 +1,2 @@
+<p><a href="https://www.foobar.com">www.foobar.com</a></p>
+<p>This is a link <a href="https://www.foobar.com">www.foobar.com</a></p>

--- a/test/functional/makehtml/cases/features/#806.https-auto-link.md
+++ b/test/functional/makehtml/cases/features/#806.https-auto-link.md
@@ -1,0 +1,3 @@
+www.foobar.com
+
+This is a link <www.foobar.com>

--- a/test/functional/makehtml/testsuite.features.js
+++ b/test/functional/makehtml/testsuite.features.js
@@ -65,6 +65,8 @@ describe('makeHtml() features testsuite', function () {
         converter = new showdown.Converter({simpleLineBreaks: true});
       } else if (testsuite[i].name === '#318.simpleLineBreaks-does-not-work-with-chinese-characters') {
         converter = new showdown.Converter({simpleLineBreaks: true});
+      } else if (testsuite[i].name === '#806.https-auto-link') {
+        converter = new showdown.Converter({simplifiedAutoLink: true, httpsAutoLinks: true});
       } else if (testsuite[i].name === 'simpleLineBreaks-handle-html-pre') {
         converter = new showdown.Converter({simpleLineBreaks: true});
       } else if (testsuite[i].name === 'excludeTrailingPunctuationFromURLs-option') {


### PR DESCRIPTION
Rebases #998 onto current `develop` and ports its change into the new event-based `link.js` (the original PR targeted `master` and predates the link-parser restructure, where `links.js` was replaced by `link.js`).

Adds the `httpsAutoLinks` option: when set, protocol-less autolinks (`www.` shortcuts) are prefixed with `https://` instead of `http://`. Applies to both naked-URL (`simplifiedAutoLink`) and angle-bracket autolinks. Fixes #806.

Changes vs the original #998:
- Ported the two `www.` -> protocol spots from the removed `links.js` into `link.js`.
- Folded in the author's follow-up commit (option `type` corrected `string` -> `boolean`).

Original work by @Faberle (Christian Faber); commit authorship preserved.

Supersedes #998.

Closes #806