### PR TITLE
ci: modernize workflows (fix failing Linux build & BrowserStack)

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -16,15 +16,12 @@ jobs:
         run: echo "COMMIT_MSG=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n 1)" >> $GITHUB_ENV
 
       - name: '📦 Checkout the repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: '🚚 Upgrade NPM'
-        run: npm install -g npm
-
-      - name: '⚙ Setup Node.js v16.x'
-        uses: actions/setup-node@v2
+      - name: '⚙ Setup Node.js v20.x'
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'npm'
 
       - name: '📖 Get current package version'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Trigger external build
         env:

--- a/.github/workflows/node.linux.yml
+++ b/.github/workflows/node.linux.yml
@@ -13,20 +13,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
-    steps: 
-      - uses: actions/checkout@v2
-
-      - name: 🚚 Upgrade NPM
-        run: npm install -g npm
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/node.win.yml
+++ b/.github/workflows/node.win.yml
@@ -16,13 +16,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/karma.browserstack.js
+++ b/karma.browserstack.js
@@ -54,26 +54,10 @@ module.exports = function (config) {
         browser_version: '10.1',
         os: 'OS X',
         os_version: 'Sierra'
-      },
-      bstack_iphoneX: {
-        base: 'BrowserStack',
-        browser: 'safari',
-        os: 'ios',
-        os_version: '11.0',
-        device: 'iPhone X',
-        real_mobile: true
-      },
-      bstack_android: {
-        base: 'BrowserStack',
-        browser: 'chrome',
-        os: 'android',
-        os_version:'4.4',
-        device: 'Samsung Galaxy Tab 4',
-        realMobile: true
       }
     },
 
-    browsers: ['bstack_chrome_windows', 'bstack_firefox_old_windows', 'bstack_firefox_latest_windows', /*'bstack_ie11_windows',*/ 'bstack_edge_windows', 'bstack_iphoneX', 'bstack_macos_safari', 'bstack_android'],
+    browsers: ['bstack_chrome_windows', 'bstack_firefox_old_windows', 'bstack_firefox_latest_windows', /*'bstack_ie11_windows',*/ 'bstack_edge_windows', 'bstack_macos_safari'],
     frameworks: ['mocha', 'chai'],
     reporters: ['dots', 'BrowserStack'],
     files: [


### PR DESCRIPTION
## Problem
The `Node Linux CI` and `BrowserStack` jobs have been failing at the **setup stage**, before any test runs:

- `🚚 Upgrade NPM` (`npm install -g npm`) runs against the runner's system Node and fails with `EACCES: permission denied, mkdir '/usr/local/share/man/man7'`.
- `actions/checkout@v2` / `actions/setup-node@v2` are deprecated; the v2 cache backend returns `Cache service responded with 400` (seen on `build (16.x)`).
- The Node matrix targets EOL releases (12/14/16/17).
- BrowserStack rejected two stale launchers (`safari ios 11.0`, `chrome android 4.4`).
- CodeQL still used the deprecated `@v1` actions (EOL Node 12).

## Fix
- **Remove** the `Upgrade NPM` step (Linux + BrowserStack) — `setup-node` already ships a current npm.
- **Bump** `checkout`/`setup-node` to `@v4` across Linux, Windows, BrowserStack, CodeQL and docs workflows; `codeql-action/*` `@v1` -> `@v3`.
- **Modernize** the Node matrix to supported LTS: `18.x, 20.x, 22.x`.
- **Drop** the invalid BrowserStack iOS 11 / Android 4.4 launchers.