### PR TITLE
docs: fix default class tutorial tag matching

### DIFF
--- a/docs/tutorials/add-default-class-to-html.md
+++ b/docs/tutorials/add-default-class-to-html.md
@@ -26,8 +26,8 @@ const classMap = {
 const bindings = Object.keys(classMap)
   .map(key => ({
     type: 'output',
-    regex: new RegExp(`<${key}(.*)>`, 'g'),
-    replace: `<${key} class="${classMap[key]}" $1>`
+    regex: new RegExp(`<${key}(?=[\\s>])`, 'g'),
+    replace: `<${key} class="${classMap[key]}"`
   }));
 
 const conv = new showdown.Converter({
@@ -42,6 +42,11 @@ const text = `
 - second item
 `;
 ```
+
+The expression matches only the opening tag name, followed by whitespace or `>`.
+This adds a class to every matching element, including multiple elements on the same
+line, without consuming their attributes or matching longer tag names (such as
+`article` when the key is `a`).
 
 With this extension, the output will be as follows:
 

--- a/test/unit/tutorial-default-classes.js
+++ b/test/unit/tutorial-default-classes.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+
+describe('default class tutorial', function () {
+  const tutorial = fs.readFileSync('docs/tutorials/add-default-class-to-html.md', 'utf8');
+  const example = tutorial.match(/const bindings = [\s\S]*?(?=const conv =)/)[0];
+
+  function convert (html, classMap) {
+    // Execute the documented bindings so the regression covers the copyable example.
+    const bindings = new Function('classMap', example + '\nreturn bindings;')(classMap);
+    return new showdown.Converter({ extensions: bindings }).makeHtml(html);
+  }
+
+  it('adds a class to both links on the same line', function () {
+    expect(convert('[one](/one) [two](/two)', { a: 'link' }))
+      .toBe('<p><a class="link" href="/one">one</a> <a class="link" href="/two">two</a></p>');
+  });
+
+  it('does not match tag names that only share a prefix', function () {
+    expect(convert('<article><a>one</a><abbr>two</abbr></article>', { a: 'link' }))
+      .toBe('<article><a class="link">one</a><abbr>two</abbr></article>');
+  });
+
+  it('preserves quoted angle brackets in attributes', function () {
+    expect(convert('<div><a title="1 > 0">one</a><a title="2 > 1">two</a></div>', { a: 'link' }))
+      .toBe('<div><a class="link" title="1 > 0">one</a><a class="link" title="2 > 1">two</a></div>');
+  });
+
+  it('preserves attributes on multiple lines', function () {
+    expect(convert('<div><a\n title="one">one</a></div>', { a: 'link' }))
+      .toBe('<div><a class="link"\n title="one">one</a></div>');
+  });
+
+  it('adds classes to the list elements from the tutorial', function () {
+    expect(convert('- one\n- two', { ul: 'list', li: 'item' }))
+      .toBe('<ul class="list">\n<li class="item">one</li>\n<li class="item">two</li>\n</ul>');
+  });
+});


### PR DESCRIPTION
Fixes #1026.

The CSS-class tutorial's greedy expression consumes the rest of the line, so two links on one line receive a class only on the first link. It can also match `article` or `abbr` when the configured tag is `a`.

Match only the opening tag name with a whitespace-or-`>` boundary, and insert the class immediately after it. Attributes remain untouched, including quoted `>` characters and attributes on multiple lines. Add a short explanation to the tutorial.

Five regression checks execute the bindings extracted from the documented snippet through the actual converter: repeated links, tag-name prefixes, quoted angle brackets, multiline attributes, and the tutorial's list classes. All five fail before the change (the list case differs only in redundant whitespace) and pass afterward.

Validation: `npm test` passes all 3,179 tests across 26 files; ESLint reports no errors and one existing unused-variable warning in `decodeEntities.js`. `git diff --check` passes. Based on `develop` as requested by CONTRIBUTING.md. No library runtime code or dependencies changed; no browser matrix was run for this documentation example.

Prepared with OpenAI Codex assistance and validated locally on Node 24 / Windows.
